### PR TITLE
add rtd config to fix build error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Read the Doc's build environment will fail to build most docs right now due an issue with urllib3. Setting the build OS to Ubuntu 20 or 22 in a config file will fix the issue.